### PR TITLE
CMAKE: Use find_package(elastix)

### DIFF
--- a/SuperBuild/ExternalElastix.cmake
+++ b/SuperBuild/ExternalElastix.cmake
@@ -20,7 +20,7 @@
 set( proj Elastix )
 
 set( ELASTIX_GIT_REPOSITORY https://github.com/SuperElastix/elastix )
-set( ELASTIX_GIT_TAG 2ac905afdb1a5a841c05ed6abf92a1bf232d1e89 )
+set( ELASTIX_GIT_TAG elx-support-find-package )
 
 UPDATE_SELX_SUPERBUILD_COMMAND(${proj})
 


### PR DESCRIPTION
This branch has been made to test if the new find_package support in elastix is backwards compatible. It should be, because find_package just defines the ELASTIX_USE_FILE, which up until now was given directly the external project. The branch should be updated to use find_package before merge if tests pass. 