### PR TITLE
A first attempt, with just a simplistic coarse affine registration

### DIFF
--- a/ContinuousRegistration/Submissions/RB/PreliminaryAffine_CUMC12.json
+++ b/ContinuousRegistration/Submissions/RB/PreliminaryAffine_CUMC12.json
@@ -1,0 +1,52 @@
+{
+    "Datasets": ["CUMC12"],
+    "Component": {
+        "Name": "Strategy",
+        "NameOfClass": "PreliminaryAffineStrategyRegistrationComponent",
+        "UserMode": "1",
+        "Strategy": "CUMC12"
+    },
+    "Component": {
+        "Name": "FixedImage",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "float",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "FixedMask",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "unsigned char",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "MovingMask",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "unsigned char",
+        "Dimensionality": "3"
+    },
+      "Component": {
+        "Name": "MovingImage",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "float",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "DisplacementField",
+        "NameOfClass": "ItkDisplacementFieldSinkComponent",
+        "Dimensionality": "3"
+    },
+    "Connection": {
+        "Out": "FixedImage",
+        "In": "Strategy",
+        "Role": "Fixed"
+    },
+    "Connection": {
+        "Out": "MovingImage",
+        "In": "Strategy",
+        "Role": "Moving"
+    },
+    "Connection": {
+        "Out": "Strategy",
+        "In": "DisplacementField"
+    }
+}

--- a/ContinuousRegistration/Submissions/RB/PreliminaryAffine_DIRLAB.json
+++ b/ContinuousRegistration/Submissions/RB/PreliminaryAffine_DIRLAB.json
@@ -1,0 +1,52 @@
+{
+    "Datasets": ["DIRLAB"],
+    "Component": {
+        "Name": "Strategy",
+        "NameOfClass": "PreliminaryAffineStrategyRegistrationComponent",
+        "UserMode": "1",
+        "Strategy": "DIRLAB"
+    },
+    "Component": {
+        "Name": "FixedImage",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "float",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "FixedMask",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "unsigned char",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "MovingMask",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "unsigned char",
+        "Dimensionality": "3"
+    },
+      "Component": {
+        "Name": "MovingImage",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "float",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "DisplacementField",
+        "NameOfClass": "ItkDisplacementFieldSinkComponent",
+        "Dimensionality": "3"
+    },
+    "Connection": {
+        "Out": "FixedImage",
+        "In": "Strategy",
+        "Role": "Fixed"
+    },
+    "Connection": {
+        "Out": "MovingImage",
+        "In": "Strategy",
+        "Role": "Moving"
+    },
+    "Connection": {
+        "Out": "Strategy",
+        "In": "DisplacementField"
+    }
+}

--- a/ContinuousRegistration/Submissions/RB/PreliminaryAffine_POPI.json
+++ b/ContinuousRegistration/Submissions/RB/PreliminaryAffine_POPI.json
@@ -1,0 +1,52 @@
+{
+    "Datasets": ["POPI"],
+    "Component": {
+        "Name": "Strategy",
+        "NameOfClass": "PreliminaryAffineStrategyRegistrationComponent",
+        "UserMode": "1",
+        "Strategy": "POPI"
+    },
+    "Component": {
+        "Name": "FixedImage",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "float",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "FixedMask",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "unsigned char",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "MovingMask",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "unsigned char",
+        "Dimensionality": "3"
+    },
+      "Component": {
+        "Name": "MovingImage",
+        "NameOfClass": "ItkImageSourceComponent",
+        "PixelType": "float",
+        "Dimensionality": "3"
+    },
+    "Component": {
+        "Name": "DisplacementField",
+        "NameOfClass": "ItkDisplacementFieldSinkComponent",
+        "Dimensionality": "3"
+    },
+    "Connection": {
+        "Out": "FixedImage",
+        "In": "Strategy",
+        "Role": "Fixed"
+    },
+    "Connection": {
+        "Out": "MovingImage",
+        "In": "Strategy",
+        "Role": "Moving"
+    },
+    "Connection": {
+        "Out": "Strategy",
+        "In": "DisplacementField"
+    }
+}

--- a/Modules/Components/PreliminaryAffineStrategy/ModulePreliminaryAffineStrategy.cmake
+++ b/Modules/Components/PreliminaryAffineStrategy/ModulePreliminaryAffineStrategy.cmake
@@ -1,0 +1,35 @@
+#=========================================================================
+#
+#  This Baseline Strategy Module developed by Rupert Brooks in the context
+#  of the Continuous Registration Challenge.  June 2018
+#
+#  Copyright Leiden University Medical Center, Erasmus University Medical 
+#  Center and contributors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0.txt
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+set( ${MODULE}_INCLUDE_DIRS
+  ${${MODULE}_SOURCE_DIR}/include
+  ${${MODULE}_SOURCE_DIR}/interfaces
+)
+
+set( ${MODULE}_SOURCE_FILES
+)
+
+set( ${MODULE}_LIBRARIES 
+)
+
+set( ${MODULE}_MODULE_DEPENDENCIES 
+  ModuleCore
+)

--- a/Modules/Components/PreliminaryAffineStrategy/include/PreliminaryAffineStrategy.h
+++ b/Modules/Components/PreliminaryAffineStrategy/include/PreliminaryAffineStrategy.h
@@ -1,0 +1,266 @@
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <functional>
+
+#include <itkVersion.h>
+#include <itkImage.h>
+#include <itkImageFileReader.h>
+#include <itkImageFileWriter.h>
+#include <itkCastImageFilter.h>
+#include <itkResampleImageFilter.h>
+#include <itkMeanSquaresImageToImageMetric.h>
+#include <itkRegularStepGradientDescentOptimizer.h>
+#include <itkLinearInterpolateImageFunction.h>
+#include <itkRecursiveMultiResolutionPyramidImageFilter.h>
+#include <itkTransformFileWriter.h>
+#include <itkMinimumMaximumImageFilter.h>
+#include <itkImageRegionIteratorWithIndex.h>
+
+#include "selxSuperElastixComponent.h"
+#include "selxSinksAndSourcesInterfaces.h"
+#include "selxItkObjectInterfaces.h"
+
+
+// Fundamentally this is to group together all the typedefs
+// The class does not truly have any state.
+template<class PixelType, unsigned int Dimension>
+struct PreliminaryAffineStrategy
+{
+    // typedef all the things
+    using Coord=double;
+    using Image=itk::Image<PixelType,Dimension>;
+    using ImagePtr=typename Image::Pointer;
+    using Point=typename Image::PointType;
+    using Vector=typename Image::PointType::VectorType;
+    using Size=typename Image::SizeType;
+    using Index=typename Image::IndexType;
+    using Region=typename Image::RegionType;
+    using ContIndex=itk::ContinuousIndex<Coord,Dimension>;
+    using Reader=itk::ImageFileReader<Image>;
+    using ReaderPtr=typename Reader::Pointer;
+    using Writer=itk::ImageFileWriter<Image>;
+    using WriterPtr=typename Writer::Pointer;
+    using InternalPixelType=float;
+    using InternalImage=itk::Image<InternalPixelType,Dimension>;
+    using InternalImagePtr=typename InternalImage::Pointer;
+    using Caster=itk::CastImageFilter<Image,InternalImage>;
+    using Pyramid=itk::RecursiveMultiResolutionPyramidImageFilter<
+                                    Image,
+                                    InternalImage >;
+    using PyramidPtr=typename Pyramid::Pointer;
+    using MeanSquaresMetric=itk::MeanSquaresImageToImageMetric<InternalImage,InternalImage>;
+    using MeanSquaresMetricPtr=typename MeanSquaresMetric::Pointer;
+    using LinearInterpolator=itk::LinearInterpolateImageFunction<Image,Coord>;
+    using LinearInterpolatorPtr=typename LinearInterpolator::Pointer;
+    using LinearInternalInterpolator=itk::LinearInterpolateImageFunction<InternalImage,Coord>;
+    using LinearInternalInterpolatorPtr=typename LinearInternalInterpolator::Pointer;
+    using AffineTransform=itk::AffineTransform<Coord,Dimension>;
+    using AffineTransformPtr=typename AffineTransform::Pointer;
+    using Parameters=typename AffineTransform::ParametersType;
+    using RSGD=itk::RegularStepGradientDescentOptimizer;
+    using RSGDPtr=RSGD::Pointer;
+    using TransformWriter=itk::TransformFileWriter;
+    using TransformWriterPtr=typename TransformWriter::Pointer;
+    using Resampler=itk::ResampleImageFilter<Image,Image>;
+    using ResamplerPtr=typename Resampler::Pointer;
+    using DisplacementField = typename itk::Image< itk::Vector<float,Dimension>, Dimension>;
+    using DisplacementFieldPtr =  typename DisplacementField::Pointer;
+ 
+
+    
+    // Params
+    std::string m_strategy;
+    std::string m_outputpath;
+    std::function<void(const int, const std::string &)> m_log;
+    
+    void ProcessImages(ImagePtr iFixedImage, ImagePtr iMovingImage, DisplacementFieldPtr oDisplacementField)
+    {
+        
+        {
+            std::ostringstream oss;
+            oss << "FixedImage size " << iFixedImage->GetLargestPossibleRegion().GetSize();
+            m_log(2,oss.str());
+        }
+        {
+            std::ostringstream oss;
+            oss << "MovingImage size " << iMovingImage->GetLargestPossibleRegion().GetSize();
+            m_log(2,oss.str());
+        }
+        
+        // Find a center
+        Parameters centre(3);
+        Parameters centreMoving(3);
+        {
+            Point ctr;
+            ContIndex index;
+            const Size sz=iFixedImage->GetLargestPossibleRegion().GetSize();
+            for ( unsigned int i=0;i<Dimension;++i ) { index[i]=static_cast<double>(sz[i] )/2.0; }
+            iFixedImage->TransformContinuousIndexToPhysicalPoint( index,ctr );
+            for ( unsigned int i=0;i<Dimension;++i ) { centre[i]=ctr[i]; }
+            
+        }
+        {
+            Point ctr;
+            ContIndex index;
+            const Size sz=iMovingImage->GetLargestPossibleRegion().GetSize();
+            for ( unsigned int i=0;i<Dimension;++i ) { index[i]=static_cast<double>(sz[i] )/2.0; }
+            iMovingImage->TransformContinuousIndexToPhysicalPoint( index,ctr );
+            for ( unsigned int i=0;i<Dimension;++i ) { centreMoving[i]=ctr[i]; }
+        }
+        {
+            std::ostringstream oss;
+            oss << "Fixedimage center " << centre;
+            m_log(2,oss.str());
+        }
+        {
+            std::ostringstream oss;
+            oss << "MovingImage center " << centreMoving;
+            m_log(2,oss.str());
+        }
+
+        // Find number of levels
+        unsigned int numberOfLevels=0;
+        {
+           unsigned int numberOfPixels=1;
+           const Size sz=iFixedImage->GetLargestPossibleRegion().GetSize();
+           for ( int i=0;i<Dimension;++i) { numberOfPixels*=sz[i]; }
+           double temp=log(( double )numberOfPixels ) /log( 2.0 )/Dimension-( 7-Dimension );
+           numberOfLevels=( temp<1 )?1:( unsigned int )floor( temp );
+        }
+        PyramidPtr fixedPyramid=Pyramid::New();
+        PyramidPtr movingPyramid=Pyramid::New();
+ 
+        // Setup the fixed image pyramid
+        fixedPyramid->SetNumberOfLevels( numberOfLevels );
+        fixedPyramid->SetInput( iFixedImage );
+        fixedPyramid->UpdateLargestPossibleRegion();
+
+        // Setup the moving image pyramid
+        movingPyramid->SetNumberOfLevels( numberOfLevels );
+        movingPyramid->SetInput( iMovingImage );
+        movingPyramid->UpdateLargestPossibleRegion();
+        
+        AffineTransformPtr affineTransform=AffineTransform::New();
+        affineTransform->SetIdentity();
+        affineTransform->SetFixedParameters(centre);
+        LinearInternalInterpolatorPtr linearInternal=LinearInternalInterpolator::New();
+        
+        MeanSquaresMetricPtr metric=MeanSquaresMetric::New();
+        InternalImagePtr reducedImage=fixedPyramid->GetOutput(0);
+        {
+            std::ostringstream oss;
+            oss << "Size of top of pyramid: " << reducedImage->GetLargestPossibleRegion().GetSize();
+            m_log(2,oss.str());
+        }
+        Region reducedImageRegion;
+        {
+            auto schedule = fixedPyramid->GetSchedule();
+            const Size inputSize=iFixedImage->GetLargestPossibleRegion().GetSize();
+            const Index inputStart=iFixedImage->GetLargestPossibleRegion().GetIndex();
+            Size  size;
+            Index start;
+            for ( unsigned int dim = 0; dim < Dimension; ++dim) {
+                const float scaleFactor = static_cast<float>( schedule[ 0 ][ dim ] );
+                size[ dim ] = static_cast<typename Size::SizeValueType>(
+                    vcl_floor(static_cast<float>( inputSize[ dim ] ) / scaleFactor ) );
+                if( size[ dim ] < 1 ) { size[ dim ] = 1;  }
+                start[ dim ] = static_cast<typename Index::IndexValueType>(
+                    vcl_ceil(static_cast<float>( inputStart[ dim ] ) / scaleFactor ) ); 
+            }
+            reducedImageRegion.SetSize(size);
+            reducedImageRegion.SetIndex(start);
+        }
+        {
+            std::ostringstream oss;
+            oss << "Reduced Image region: " << reducedImageRegion.GetIndex() << " size "<< reducedImageRegion.GetSize();
+            m_log(2,oss.str());
+        }
+
+        
+        metric->SetMovingImage(movingPyramid->GetOutput(0));
+        metric->SetFixedImage(fixedPyramid->GetOutput(0));
+        metric->SetFixedImageRegion(reducedImageRegion);
+        metric->SetTransform(affineTransform);
+        
+        metric->SetInterpolator(linearInternal);
+        
+        metric->Initialize();
+        
+        RSGDPtr optimizer=RSGD::New();
+        optimizer->SetCostFunction(metric);
+        //Todo: use principled method here.
+        Parameters initialParameters=affineTransform->GetParameters();
+        Parameters optimizerScales(affineTransform->GetNumberOfParameters());
+        optimizerScales.Fill(72.*72);
+        optimizerScales[9]=1.0;
+        optimizerScales[10]=1.0;
+        optimizerScales[11]=1.0;
+        optimizer->SetScales(optimizerScales);
+        optimizer->SetInitialPosition(initialParameters);
+        {
+            std::ostringstream oss;
+            oss << "Initial parameters: " << initialParameters;
+            m_log(2,oss.str());
+        }
+
+        // do the optimization
+        optimizer->StartOptimization();
+
+        // get the results
+        Parameters lastTransformParameters = optimizer->GetCurrentPosition();
+        affineTransform->SetParameters( lastTransformParameters );
+        
+        {
+            std::ostringstream oss;
+            oss << "Found optimal parameters " << lastTransformParameters;
+            m_log(2,oss.str());
+        }
+        oDisplacementField->CopyInformation(iFixedImage);
+        oDisplacementField->Allocate();
+        itk::ImageRegionIteratorWithIndex<DisplacementField> fieldIter(oDisplacementField,oDisplacementField->GetLargestPossibleRegion());
+
+        for(fieldIter.GoToBegin();!fieldIter.IsAtEnd();++fieldIter)
+	{
+		Point p;
+		oDisplacementField->TransformIndexToPhysicalPoint(fieldIter.GetIndex(),p);
+                Point q=affineTransform->TransformPoint(p);
+                fieldIter.Set(q-p);
+	}
+
+        // if output requested, resample image and save transform
+        if (!m_outputpath.empty()) {
+            TransformWriterPtr twriter=TransformWriter::New();
+            twriter->SetFileName(m_outputpath+"BaseRegistrationTransform.tfm");
+            twriter->SetInput(affineTransform);
+            twriter->Update();
+            
+            auto filter=itk::MinimumMaximumImageFilter<Image>::New();
+            filter->SetInput(iFixedImage);
+            filter->Update();
+            PixelType theMinimum = filter->GetMinimum();
+            {
+                std::ostringstream oss;
+                oss << "Found minimum value " << theMinimum;
+                m_log(2,oss.str());
+            }
+            
+
+            ResamplerPtr resampler=Resampler::New();
+            resampler->SetInput(iMovingImage);
+            resampler->SetTransform(affineTransform);
+            LinearInterpolatorPtr linear=LinearInterpolator::New();
+            resampler->SetInterpolator(linear);
+            resampler->SetReferenceImage(iFixedImage);
+            resampler->UseReferenceImageOn();
+            resampler->SetDefaultPixelValue(theMinimum);
+            
+            WriterPtr writer=Writer::New();
+            writer->SetFileName(m_outputpath+"BaseRegistrationResult.mha");
+            writer->SetInput(resampler->GetOutput());
+            writer->Update();
+        }
+ 
+        
+    }
+   }; 

--- a/Modules/Components/PreliminaryAffineStrategy/include/selxModulePreliminaryAffineStrategy.h
+++ b/Modules/Components/PreliminaryAffineStrategy/include/selxModulePreliminaryAffineStrategy.h
@@ -1,0 +1,37 @@
+/*=========================================================================
+*
+*  This Preliminary affine Strategy Module developed by Rupert Brooks in the context
+*  of the Continuous Registration Challenge.  June 2018
+*
+*  Copyright Leiden University Medical Center, Erasmus University Medical
+*  Center and contributors
+*
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*        http://www.apache.org/licenses/LICENSE-2.0.txt
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+*=========================================================================*/
+
+#include "selxTypeList.h"
+#include "selxPreliminaryAffineStrategyRegistrationComponent.h"
+namespace selx
+{
+using ModulePreliminaryAffineStrategyComponents = selx::TypeList<
+	//PreliminaryAffineStrategyRegistrationComponent< 2, unsigned char>,
+	//PreliminaryAffineStrategyRegistrationComponent< 3, unsigned char>,
+	//PreliminaryAffineStrategyRegistrationComponent< 2, unsigned short>,
+	//PreliminaryAffineStrategyRegistrationComponent< 3, unsigned short>,
+	//PreliminaryAffineStrategyRegistrationComponent< 2, short>,
+	//PreliminaryAffineStrategyRegistrationComponent< 3, short>,
+	PreliminaryAffineStrategyRegistrationComponent< 2, float>,
+	PreliminaryAffineStrategyRegistrationComponent< 3, float>
+  >;
+}

--- a/Modules/Components/PreliminaryAffineStrategy/include/selxPreliminaryAffineStrategyRegistrationComponent.h
+++ b/Modules/Components/PreliminaryAffineStrategy/include/selxPreliminaryAffineStrategyRegistrationComponent.h
@@ -1,0 +1,116 @@
+/*=========================================================================
+ *
+ *  This Preliminary Affine Strategy Module developed by Rupert Brooks in the context
+ *  of the Continuous Registration Challenge.  June 2018
+ *
+ *  Copyright Leiden University Medical Center, Erasmus University Medical
+ *  Center and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef selxPreliminaryAffineStrategyRegistrationComponent_h
+#define selxPreliminaryAffineStrategyRegistrationComponent_h
+
+#include "selxSuperElastixComponent.h"
+#include "selxSinksAndSourcesInterfaces.h"
+#include "selxItkObjectInterfaces.h"
+
+#include "itkImageSource.h"
+#include <array>
+#include <algorithm>
+#include <string>
+
+
+namespace selx
+{
+template< int Dimensionality, class TPixel >
+class PreliminaryAffineStrategyRegistrationComponent :
+  public SuperElastixComponent<
+  Accepting<
+  itkImageFixedInterface< Dimensionality, TPixel >,
+  itkImageMovingInterface< Dimensionality, TPixel >
+  >,
+  Providing< UpdateInterface,
+  itkDisplacementFieldInterface< Dimensionality, TPixel >
+  >
+  >
+{
+public:
+
+  /** Standard ITK typedefs. */
+  typedef PreliminaryAffineStrategyRegistrationComponent<
+    Dimensionality, TPixel
+    >                                      Self;
+  typedef SuperElastixComponent<
+    Accepting<
+    itkImageFixedInterface< Dimensionality, TPixel >,
+    itkImageMovingInterface< Dimensionality, TPixel >
+    >,
+    Providing< UpdateInterface,
+    itkDisplacementFieldInterface< Dimensionality, float >
+    >
+    > Superclass;
+  typedef std::shared_ptr< Self >       Pointer;
+  typedef std::shared_ptr< const Self > ConstPointer;
+
+  PreliminaryAffineStrategyRegistrationComponent( const std::string & name, LoggerImpl & logger );
+  virtual ~PreliminaryAffineStrategyRegistrationComponent();
+
+  typedef typename ComponentBase::CriterionType CriterionType;
+  typedef TPixel                                PixelType;
+
+  // fixed and moving image types are all the same, these aliases can be used to be explicit. 
+  using MovingImageType = typename itkImageMovingInterface< Dimensionality, TPixel >::ItkImageType;
+  using ResultImageType = typename itkImageInterface< Dimensionality, TPixel >::ItkImageType;
+  using DisplacementFieldType = typename itkDisplacementFieldInterface< Dimensionality, float >::ItkDisplacementFieldType;
+  
+  // Accepting Interfaces:
+  virtual int Accept( typename itkImageFixedInterface< Dimensionality, TPixel >::Pointer ) override;
+
+  virtual int Accept( typename itkImageMovingInterface< Dimensionality, TPixel >::Pointer ) override;
+
+  // Providing Interfaces:
+  virtual typename DisplacementFieldType::Pointer GetItkDisplacementField() override;
+
+  virtual void Update() override;
+
+  virtual bool MeetsCriterion( const CriterionType & criterion ) override;
+
+  static const char * GetDescription() { return "PreliminaryAffineStrategyRegistration Component"; }
+
+private:
+
+  typename DisplacementFieldType::Pointer m_DisplacementField;
+  typename itkImageFixedInterface< Dimensionality, TPixel >::Pointer m_ImageFixedInterface;
+  typename itkImageMovingInterface< Dimensionality, TPixel >::Pointer m_ImageMovingInterface;
+
+  std::array<float, 3> m_demoParameter;
+  int m_userMode;
+  std::string m_strategy;
+
+
+protected:
+
+  // return the class name and the template arguments to uniquely identify this component.
+  static inline const std::map< std::string, std::string > TemplateProperties()
+  {
+    return { { keys::NameOfClass, "PreliminaryAffineStrategyRegistrationComponent" }, { keys::PixelType, PodString< TPixel >::Get() }, { keys::Dimensionality, std::to_string( Dimensionality ) } };
+  }
+};
+} //end namespace selx
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "selxPreliminaryAffineStrategyRegistrationComponent.hxx"
+#endif
+#endif // #define selxPreliminaryAffineStrategyRegistrationComponent_h

--- a/Modules/Components/PreliminaryAffineStrategy/include/selxPreliminaryAffineStrategyRegistrationComponent.hxx
+++ b/Modules/Components/PreliminaryAffineStrategy/include/selxPreliminaryAffineStrategyRegistrationComponent.hxx
@@ -1,0 +1,142 @@
+/*=========================================================================
+ *
+ *  This PreliminaryAffine Strategy Module developed by Rupert Brooks in the context
+ *  of the Continuous Registration Challenge.  June 2018
+ *
+ *  Copyright Leiden University Medical Center, Erasmus University Medical
+ *  Center and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "selxPreliminaryAffineStrategyRegistrationComponent.h"
+#include "selxCheckTemplateProperties.h"
+#include <string>
+#include "PreliminaryAffineStrategy.h"
+namespace selx
+{
+template< int Dimensionality, class TPixel >
+PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >::PreliminaryAffineStrategyRegistrationComponent( const std::string & name,
+  LoggerImpl & logger ) : Superclass( name, logger ), m_userMode(-1)
+{
+	this->m_DisplacementField = DisplacementFieldType::New();
+}
+
+
+template< int Dimensionality, class TPixel >
+PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >::~PreliminaryAffineStrategyRegistrationComponent()
+{
+}
+
+
+template< int Dimensionality, class TPixel >
+int
+PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >::Accept( typename itkImageFixedInterface< Dimensionality, TPixel >::Pointer component )
+{
+  // Since SuperElastix is an itk filter in a pipeline, we need to set the domain of the resulting deformation field before running the registration.
+  // As done in pairwise registration, typically, we use the domain of the fixed image for that.
+  auto fixed = component->GetItkImageFixed();
+  fixed->UpdateOutputInformation();
+  auto size = fixed->GetLargestPossibleRegion().GetSize();
+  this->m_DisplacementField->SetRegions(size);
+
+  auto spacing = fixed->GetSpacing();
+  this->m_DisplacementField->SetSpacing(spacing);
+
+  auto origin = fixed->GetOrigin();
+  this->m_DisplacementField->SetOrigin(origin);
+
+  auto direction = fixed->GetDirection();
+  this->m_DisplacementField->SetDirection(direction);
+
+  this->m_ImageFixedInterface = component;
+  return 0;
+}
+
+
+template< int Dimensionality, class TPixel >
+int
+PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >::Accept( typename itkImageMovingInterface< Dimensionality, TPixel >::Pointer component )
+{
+  this->m_ImageMovingInterface = component;
+  return 0;
+}
+
+
+template< int Dimensionality, class TPixel >
+typename PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >::DisplacementFieldType::Pointer
+PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >::GetItkDisplacementField()
+{
+
+  return this->m_DisplacementField;
+}
+
+template< int Dimensionality, class TPixel >
+void
+PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >::Update( void )
+{
+  auto fixed = this->m_ImageFixedInterface->GetItkImageFixed();
+  auto moving = this->m_ImageMovingInterface->GetItkImageMoving();
+  
+  fixed->SetRequestedRegionToLargestPossibleRegion();
+  fixed->Update();
+  // Raw pixel data is accessible by GetBufferPointer()
+  moving->SetRequestedRegionToLargestPossibleRegion();
+  moving->Update();
+  // Raw pixel data is accessible by GetBufferPointer()
+  PreliminaryAffineStrategy<TPixel,Dimensionality> p;
+  p.m_strategy=m_strategy;
+  p.m_log=[this](const int lvl,const std::string & message)->void {this->m_Logger.Log(LogLevel::TRC,message);};
+  p.ProcessImages(fixed,moving,this->m_DisplacementField);
+
+  // Here you can implement your registration algorithm using the fixed and moving image.
+  // For an Identity Transform it is just creating a vector field with zeros.
+  this->m_DisplacementField->Allocate();
+}
+
+template< int Dimensionality, class TPixel >
+bool
+PreliminaryAffineStrategyRegistrationComponent< Dimensionality, TPixel >
+::MeetsCriterion( const CriterionType & criterion )
+{
+  // Each criterion is a property key-value pair set at the component by the user and is handled here one at the time.
+  // First, check if the key is a template parameter and if the value corresponds to this component's instantiation.
+  auto status = CheckTemplateProperties( this->TemplateProperties(), criterion );
+  if( status == CriterionStatus::Satisfied )
+  {
+    return true; // The key is recognized and the value is correct
+  }
+  else if( status == CriterionStatus::Failed )
+  {
+    return false; // The key is recognized, but the value is incorrect
+  } // else: CriterionStatus::Unknown
+  std::ostringstream oss;
+  oss << "Criterion function: got key: " << criterion.first << " and values:";
+  for (auto c : criterion.second) {oss << " " << c;}
+  this->m_Logger.Log(LogLevel::TRC, oss.str());
+  if (criterion.first == "UserMode")
+  {
+     m_userMode=std::stoi(criterion.second[0]);
+  } else if (criterion.first == "Strategy")
+  {
+    m_strategy=criterion.second[0];
+  }
+     
+  //this->m_Logger.Log(LogLevel::TRC, std::string("Criterion function: got key: ") + criterion.first + "and value: " + criterion.second);
+  
+  // More check may follow.
+  
+  return true;
+}
+} //end namespace selx


### PR DESCRIPTION
This is just a minimal example using an affine transform to see if the process will work end to end.  It should generate (probably poor) results on DIRLAB, CUMC and POPI.  

After going through this experience, it was somewhat trickier than I thought.  I am currently having difficulties compiling when the input image type is not float.  It has to do with the displacement field also wanting to use the same pixel type for its vector, but there is something more to it than just that and I have not yet gotten it to work. (see comments in code below)

Also, I realized something that would be very helpful would be a trivial leaderboard case - a geometric shape or something - which would act as a verifier that the algorithm being run is doing what I think it is.  My own set up for testing is someway removed from the setup for the leaderboard.  For example, I have some concern I am not pointing the displacement field the right way, and so forth.  A trivial case would test all that automation.