### PR TITLE
Fix xcode travis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,12 @@ if( ${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC )
       "Please move the build directory to a directory with a shorter path."
     )
   endif()
-
+  
+  # Avoid many warnings, originating mainly from NiftyReg
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  # Avoid many warnings, originating mainly from GoogleTest
+  add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+  
   # Explicitly add INCREMENTAL linking option to command lines.
   # http://www.cmake.org/pipermail/cmake/2010-February/035174.html
   # set( MSVC_INCREMENTAL_DEFAULT ON )
@@ -87,6 +92,13 @@ if( WIN32 )
   # If building on Windows: The target machine should be Windows 7 or higher.
   # Note that the Windows version should match with BOOST_USE_WINAPI_VERSION. 
   add_definitions(-D_WIN32_WINNT=0x0601)
+endif()
+
+if( ${CMAKE_GENERATOR} STREQUAL Xcode )
+  # Suppress warning about inconsistent missing 'override' in method GetComponentName in SuperElastixComponent; \todo: fix it in the code.
+  if( ( ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU) OR ( ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang ) )
+    add_compile_options("-Wno-inconsistent-missing-override")
+  endif()
 endif()
 
 # ---------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 # Suppress warning on Travis about inconsistent missing 'override'
 # in method GetComponentName in SuperElastixComponent; 
 # \todo: fix it in the code.
-if( ${CMAKE_CXX_COMPILER_ID} STREQUAL AppleClang ) )
+if( ${CMAKE_CXX_COMPILER_ID} STREQUAL AppleClang )
   add_compile_options("-Wno-inconsistent-missing-override")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,15 +94,12 @@ if( WIN32 )
   add_definitions(-D_WIN32_WINNT=0x0601)
 endif()
 
-#if( ${CMAKE_GENERATOR} STREQUAL Xcode )
-  # Suppress warning about inconsistent missing 'override' in method GetComponentName in SuperElastixComponent; \todo: fix it in the code.
-#	  if( ( ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU) OR ( ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang ) )
-    add_compile_options("-Wno-inconsistent-missing-override")
-    MESSAGE(WARNING "${CMAKE_GENERATOR}" )
-    MESSAGE(WARNING "${CMAKE_CXX_COMPILER_ID}" )
-    MESSAGE(WARNING "${CMAKE_CXX_FLAGS}" )
-    #  endif()
-#endif()
+# Suppress warning on Travis about inconsistent missing 'override'
+# in method GetComponentName in SuperElastixComponent; 
+# \todo: fix it in the code.
+if( ${CMAKE_CXX_COMPILER_ID} STREQUAL AppleClang ) )
+  add_compile_options("-Wno-inconsistent-missing-override")
+endif()
 
 # ---------------------------------------------------------------------
 # Use SuperBuild. 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,12 +94,15 @@ if( WIN32 )
   add_definitions(-D_WIN32_WINNT=0x0601)
 endif()
 
-if( ${CMAKE_GENERATOR} STREQUAL Xcode )
+#if( ${CMAKE_GENERATOR} STREQUAL Xcode )
   # Suppress warning about inconsistent missing 'override' in method GetComponentName in SuperElastixComponent; \todo: fix it in the code.
-  if( ( ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU) OR ( ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang ) )
+#	  if( ( ${CMAKE_CXX_COMPILER_ID} STREQUAL GNU) OR ( ${CMAKE_CXX_COMPILER_ID} STREQUAL Clang ) )
     add_compile_options("-Wno-inconsistent-missing-override")
-  endif()
-endif()
+    MESSAGE(WARNING "${CMAKE_GENERATOR}" )
+    MESSAGE(WARNING "${CMAKE_CXX_COMPILER_ID}" )
+    MESSAGE(WARNING "${CMAKE_CXX_FLAGS}" )
+    #  endif()
+#endif()
 
 # ---------------------------------------------------------------------
 # Use SuperBuild. 

--- a/Modules/Components/ItkSmoothingRecursiveGaussianImageFilter/include/selxItkSmoothingRecursiveGaussianImageFilterComponent.hxx
+++ b/Modules/Components/ItkSmoothingRecursiveGaussianImageFilter/include/selxItkSmoothingRecursiveGaussianImageFilterComponent.hxx
@@ -90,7 +90,7 @@ ItkSmoothingRecursiveGaussianImageFilterComponent< Dimensionality, TPixel >
         this->m_theItkFilter->SetSigma( std::stod( criterionValue ) );
         meetsCriteria = true;
       }
-      catch( itk::ExceptionObject & err )
+      catch( itk::ExceptionObject & itkNotUsed(err) )
       {
         //TODO log the error message?
         meetsCriteria = false;

--- a/Modules/Components/itkImageRegistrationMethodv4/include/selxItkANTSNeighborhoodCorrelationImageToImageMetricv4Component.hxx
+++ b/Modules/Components/itkImageRegistrationMethodv4/include/selxItkANTSNeighborhoodCorrelationImageToImageMetricv4Component.hxx
@@ -105,7 +105,7 @@ ItkANTSNeighborhoodCorrelationImageToImageMetricv4Component< Dimensionality, TPi
         this->m_theItkFilter->SetRadius( radius );
         return true;
       }
-      catch( itk::ExceptionObject & err )
+      catch( itk::ExceptionObject & itkNotUsed(err) )
       {
         //TODO log the error message?
         return false;

--- a/Modules/Components/itkImageRegistrationMethodv4/include/selxItkGradientDescentOptimizerv4Component.hxx
+++ b/Modules/Components/itkImageRegistrationMethodv4/include/selxItkGradientDescentOptimizerv4Component.hxx
@@ -83,7 +83,7 @@ ItkGradientDescentOptimizerv4Component< InternalComputationValueType >
         this->m_Optimizer->SetNumberOfIterations( std::stoi( criterionValue ) );
         meetsCriteria = true;
       }
-      catch( itk::ExceptionObject & err )
+      catch( itk::ExceptionObject & itkNotUsed(err) )
       {
         //TODO log the error message?
         meetsCriteria = false;
@@ -106,7 +106,7 @@ ItkGradientDescentOptimizerv4Component< InternalComputationValueType >
         //this->m_Optimizer->SetLearningRate(std::stod(criterionValue));
         meetsCriteria = true;
       }
-      catch( itk::ExceptionObject & err ) // TODO: should catch(const bad_lexical_cast &) too
+      catch( itk::ExceptionObject & itkNotUsed(err) ) // TODO: should catch(const bad_lexical_cast &) too
       {
         //TODO log the error message?
         meetsCriteria = false;

--- a/Modules/Core/include/selxComponentBase.h
+++ b/Modules/Core/include/selxComponentBase.h
@@ -54,6 +54,9 @@ public:
 
   typedef std::map< std::string, std::string > InterfaceCriteriaType;
 
+  // Will be implemented in SuperElastixComponent so that any interface can add a GetComponentName method without the need to implement that in each component individually.
+  //virtual const typename std::string GetComponentName() = 0;
+
   virtual int AcceptConnectionFrom( Pointer, const InterfaceCriteriaType ) = 0;
 
   virtual int AcceptConnectionFrom( Pointer ) = 0;


### PR DESCRIPTION
In case of AppleClang compiler the option -Wno-inconsistent-missing-override is now passed. This branch should suppress some warnings in MSVC, and also in Xcode AppleClang on Travis.
