### PR TITLE
Revert "CMAKE: Disable ctest_submit", to get Test results back at trunk.cdash.org

### DIFF
--- a/CTest.cmake
+++ b/CTest.cmake
@@ -58,7 +58,7 @@ ctest_start("Continuous")
 # Added ctest_update() to ensure that the commit SHA will be passed to CDash, and GitHub.
 ctest_update()
 ctest_test(RETURN_VALUE RES)
-# ctest_submit( PARTS Test Update )
+ctest_submit( PARTS Test Update )
 
 if (RES)
   message(FATAL_ERROR "Unit tests have return code != 0")


### PR DESCRIPTION
This reverts commit 198ae21b6c9491035541a2ba6176079dc3cd105e.
Should fix issue #304 (Our CDash dashboard no longer displays Test results)