### PR TITLE
BUG: I could not run Python scripts as modules.

### DIFF
--- a/ContinuousRegistration/Source/datasets.py
+++ b/ContinuousRegistration/Source/datasets.py
@@ -1,10 +1,10 @@
-import glob, csv, re
+import glob, csv, re, os, stat
 from abc import ABCMeta
 from itertools import combinations
 
-from ContinuousRegistration.Source.metrics import tre, hausdorff, inverse_consistency_labels, \
+from metrics import tre, hausdorff, inverse_consistency_labels, \
     inverse_consistency_points, label_overlap
-from ContinuousRegistration.Source.util import *
+from util import *
 
 class Dataset:
     """
@@ -37,6 +37,9 @@ class Dataset:
                 os.path.join(output_directory, file_names['disp_field_file_names'][0]),
                 os.path.splitext(shell_script_file_name_0)[0] + '.log'))
 
+        # make shell script executable (like 'chmod +x' )        
+        os.chmod(shell_script_file_name_0, os.stat(shell_script_file_name_0).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        
         logging.info('Wrote %s' % shell_script_file_name_0)
 
         # Fixed=image1, Moving=image0, Output: image0_to_image1

--- a/ContinuousRegistration/Source/make_registration_scripts.py
+++ b/ContinuousRegistration/Source/make_registration_scripts.py
@@ -1,6 +1,6 @@
 import os, json, argparse
-from ContinuousRegistration.Source.datasets import logging, load_datasets
-from ContinuousRegistration.Source.util import load_submissions
+from datasets import logging, load_datasets
+from util import load_submissions
 
 parser = argparse.ArgumentParser(description='Continuous Registration Challenge command line interface.')
 parser.add_argument('--superelastix', '-selx', required=True,

--- a/ContinuousRegistration/Source/metrics.py
+++ b/ContinuousRegistration/Source/metrics.py
@@ -1,7 +1,7 @@
 import numpy as np
 import SimpleITK as sitk
-from ContinuousRegistration.Source.util import warp_image, warp_point_set
-from ContinuousRegistration.Source.util import logging
+from util import warp_image, warp_point_set
+from util import logging
 
 def tre(superelastix, point_sets, deformation_field_file_names):
     try:


### PR DESCRIPTION
I got:
python -m ContinuousRegistration.Source.make_registration_scripts.py
/usr/bin/python: Error while finding module specification for 'ContinuousRegistration.Source.make_registration_scripts.py' (AttributeError: module 'ContinuousRegistration.Source.make_registration_scripts' has no attribute '__path__')

Removing the relative imports, and not using -m,  worked for me.

ENH: set shell script permissions by python (no manual chmod needed
anymore)