### PR TITLE
COMP: Upgraded GoogleTest to 1.8.1

### DIFF
--- a/Testing/googletest.cmake.in
+++ b/Testing/googletest.cmake.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           release-1.8.0
+  GIT_TAG           release-1.8.1
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/Testing/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/Testing/googletest-build"
   UPDATE_COMMAND    ""


### PR DESCRIPTION
Upgraded GoogleTest to 1.8.1, to fix VS2017 build errors:
error C2220 warning treated as error: no 'object' file generated [SuperElastix-build\Testing\googletest-build\googlemock\gmock.vcxproj] [F:\X\Bin\vc141-64\SelxDev\D\SuperElastix-build\Testing\googletest-download\googletest.vcxproj] SuperElastix-build\Testing\googletest-src\googletest\include\gtest\internal\gtest-port.h

gtest 1.8.1 is from August 2018 (whereas gtest 1.8.0 was from July 2016).