### PR TITLE
BlueprintImpl fixes + support of relative paths to composable Blueprint file

### DIFF
--- a/ContinuousRegistration/Submissions/ComposableBlueprints/AffineTransform.json
+++ b/ContinuousRegistration/Submissions/ComposableBlueprints/AffineTransform.json
@@ -2,8 +2,8 @@
     "Datasets": ["POPI", "DIRLAB", "EMPIRE", "LPBA40", "ISBR18", "CUMC12", "MGH10", "SPREAD", "HAMMERS"],
     "Include": 
         [
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/elastix_transformix_base.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/Input_Output_3d_float.json"
+             "Composables/elastix_transformix_base.json",
+             "Composables/Input_Output_3d_float.json"
         ],
     "Components": [
         {

--- a/ContinuousRegistration/Submissions/ComposableBlueprints/BSplineTransformBrains.json
+++ b/ContinuousRegistration/Submissions/ComposableBlueprints/BSplineTransformBrains.json
@@ -2,8 +2,8 @@
     "Datasets": ["ISBR18", "LPBA40", "MGH10", "CUMC12", "HAMMERS"],
     "Include": 
         [
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/elastix_transformix_base.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/Input_Output_3d_float.json"
+             "Composables/elastix_transformix_base.json",
+             "Composables/Input_Output_3d_float.json"
         ],
     "Components": [
         {

--- a/ContinuousRegistration/Submissions/ComposableBlueprints/BSplineTransformDIRLAB.json
+++ b/ContinuousRegistration/Submissions/ComposableBlueprints/BSplineTransformDIRLAB.json
@@ -2,8 +2,8 @@
     "Datasets": ["DIRLAB", "EMPIRE", "SPREAD"],
     "Include": 
         [
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/elastix_transformix_base.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/Input_Output_3d_float.json"
+             "Composables/elastix_transformix_base.json",
+             "Composables/Input_Output_3d_float.json"
         ],
     "Components": [
         {

--- a/ContinuousRegistration/Submissions/ComposableBlueprints/BSplineTransformPOPI.json
+++ b/ContinuousRegistration/Submissions/ComposableBlueprints/BSplineTransformPOPI.json
@@ -2,8 +2,8 @@
     "Datasets": ["POPI", "EMPIRE", "SPREAD"],
     "Include": 
         [
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/elastix_transformix_base.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/Input_Output_3d_float.json"
+             "Composables/elastix_transformix_base.json",
+             "Composables/Input_Output_3d_float.json"
         ],
     "Components": [
         {

--- a/ContinuousRegistration/Submissions/ComposableBlueprints/ITKv4_SVF_ANTsNC.json
+++ b/ContinuousRegistration/Submissions/ComposableBlueprints/ITKv4_SVF_ANTsNC.json
@@ -2,11 +2,11 @@
     "Datasets": ["POPI", "DIRLAB", "EMPIRE", "LPBA40", "ISBR18", "CUMC12", "MGH10", "SPREAD", "HAMMERS"],
     "Include": 
         [
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_base.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_Reg.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/Input_Output_3d_float.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_SVF.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_ANTsNC.json"
+             "Composables/ITKv4_base.json",
+             "Composables/ITKv4_Reg.json",
+             "Composables/Input_Output_3d_float.json",
+             "Composables/ITKv4_SVF.json",
+             "Composables/ITKv4_ANTsNC.json"
         ],
     "Components": [
         {

--- a/ContinuousRegistration/Submissions/ComposableBlueprints/ITKv4_SVF_MSD.json
+++ b/ContinuousRegistration/Submissions/ComposableBlueprints/ITKv4_SVF_MSD.json
@@ -2,11 +2,11 @@
     "Datasets": ["POPI", "DIRLAB", "EMPIRE", "LPBA40", "ISBR18", "CUMC12", "MGH10", "SPREAD", "HAMMERS"],
     "Include": 
         [
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_base.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_Reg.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/Input_Output_3d_float.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_SVF.json",
-             "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_MSD.json"
+             "Composables/ITKv4_base.json",
+             "Composables/ITKv4_Reg.json",
+             "Composables/Input_Output_3d_float.json",
+             "Composables/ITKv4_SVF.json",
+             "Composables/ITKv4_MSD.json"
         ],
     "Components": [
         {

--- a/ContinuousRegistration/Submissions/ComposableBlueprints/ITKv4_SyN_ANTsNC.json
+++ b/ContinuousRegistration/Submissions/ComposableBlueprints/ITKv4_SyN_ANTsNC.json
@@ -12,9 +12,9 @@
     ],
     "Include": 
     [
-        "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_base.json",
-        "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/Input_Output_3d_float.json",
-        "./ContinuousRegistration/Submissions/ComposableBlueprints/Composables/ITKv4_ANTsNC.json"
+        "Composables/ITKv4_base.json",
+        "Composables/Input_Output_3d_float.json",
+        "Composables/ITKv4_ANTsNC.json"
     ],
     "Components": [
         {

--- a/Modules/Blueprints/src/selxBlueprintImpl.cxx
+++ b/Modules/Blueprints/src/selxBlueprintImpl.cxx
@@ -523,6 +523,7 @@ void
 BlueprintImpl::MergeFromFile(const std::string & fileNameString)
 {
   const PathType fileName(fileNameString);
+  const auto parentPath = fileName.parent_path();
 
   this->m_LoggerImpl->Log(LogLevel::INF, "Loading {0} ... ", fileName);
   const auto propertyTree = ReadPropertyTree(fileName);
@@ -533,7 +534,16 @@ BlueprintImpl::MergeFromFile(const std::string & fileNameString)
   for (auto const & includePath : FindIncludes(propertyTree))
   {
     this->m_LoggerImpl->Log(LogLevel::INF, "Including file {0} ... ", includePath);
-    this->MergeFromFile(includePath.string());
+
+    if (includePath.is_relative() && ! parentPath.empty())
+    {
+      const auto absoluteIncludePath = parentPath / includePath;
+      this->MergeFromFile(absoluteIncludePath.string());
+    }
+    else
+    {
+      this->MergeFromFile(includePath.string());
+    }
   }
   this->m_LoggerImpl->Log(LogLevel::INF, "Checking {0} for include files ... done", fileName);
   this->MergeProperties(propertyTree);

--- a/Modules/Blueprints/src/selxBlueprintImpl.cxx
+++ b/Modules/Blueprints/src/selxBlueprintImpl.cxx
@@ -17,11 +17,24 @@
  *
  *=========================================================================*/
 
+
+#ifdef _MSC_VER
+#  if _MSC_VER == 1916 // Visual Studio 2017 version 15.9
+#    ifdef _PREFAST_ // Defined as 1 when the /analyze compiler option is set.
+// Warning C26489 often appears as a false positive:
+// https://developercommunity.visualstudio.com/content/problem/469978/c-code-analysis-false-positives-c26489-on-stdmap.html
+#pragma warning(disable: 26489) // Don't dereference a pointer that may be invalid: '...' may have been invalidated at line ... (lifetime.1).
+#    endif
+#  endif
+#endif
+
+
 #include "selxBlueprintImpl.h"
 #include "selxLoggerImpl.h"
 #include <ostream>
 
 #include <stdexcept>
+
 
 namespace selx
 {

--- a/Modules/Blueprints/src/selxBlueprintImpl.cxx
+++ b/Modules/Blueprints/src/selxBlueprintImpl.cxx
@@ -522,22 +522,18 @@ BlueprintImpl::VectorizeValues(const PropertyTreeType& componentOrConnectionTree
 void
 BlueprintImpl::MergeFromFile(const std::string & fileNameString)
 {
-  PathType fileName(fileNameString);
+  const PathType fileName(fileNameString);
 
   this->m_LoggerImpl->Log(LogLevel::INF, "Loading {0} ... ", fileName);
-  auto propertyTree = ReadPropertyTree(fileName);
+  const auto propertyTree = ReadPropertyTree(fileName);
   this->m_LoggerImpl->Log(LogLevel::INF, "Loading {0} ... Done", fileName);
 
   this->m_LoggerImpl->Log(LogLevel::INF, "Checking {0} for include files ... ", fileName);
-  auto includesList = FindIncludes(propertyTree);
 
-  if (!includesList.empty())
+  for (auto const & includePath : FindIncludes(propertyTree))
   {
-    for (auto const & includePath : includesList)
-    {
-      this->m_LoggerImpl->Log(LogLevel::INF, "Including file {0} ... ", includePath);
-      this->MergeFromFile(includePath.string());
-    }
+    this->m_LoggerImpl->Log(LogLevel::INF, "Including file {0} ... ", includePath);
+    this->MergeFromFile(includePath.string());
   }
   this->m_LoggerImpl->Log(LogLevel::INF, "Checking {0} for include files ... done", fileName);
   this->MergeProperties(propertyTree);

--- a/Modules/Blueprints/src/selxBlueprintImpl.cxx
+++ b/Modules/Blueprints/src/selxBlueprintImpl.cxx
@@ -497,7 +497,7 @@ BlueprintImpl
 }
 
 BlueprintImpl::ParameterValueType
-BlueprintImpl::VectorizeValues(ComponentOrConnectionTreeType & componentOrConnectionTree)
+BlueprintImpl::VectorizeValues(const PropertyTreeType& componentOrConnectionTree)
 {
   std::string        propertySingleValue = componentOrConnectionTree.data();
   ParameterValueType propertyMultiValue;

--- a/Modules/Blueprints/src/selxBlueprintImpl.cxx
+++ b/Modules/Blueprints/src/selxBlueprintImpl.cxx
@@ -579,7 +579,7 @@ BlueprintImpl::FindIncludes(const PropertyTreeType & propertyTree)
   {
     if (FoundIncludes)
     {
-      std::runtime_error("Only 1 listing of Includes is allowed per Blueprint file");
+      throw std::runtime_error("Only 1 listing of Includes is allowed per Blueprint file");
     }
 
     auto const pathsStrings = VectorizeValues(v.second);

--- a/Modules/Blueprints/src/selxBlueprintImpl.cxx
+++ b/Modules/Blueprints/src/selxBlueprintImpl.cxx
@@ -574,20 +574,18 @@ BlueprintImpl::PathsType
 BlueprintImpl::FindIncludes(const PropertyTreeType & propertyTree)
 {
   PathsType paths;
-  bool FoundIncludes = false;
-  BOOST_FOREACH(const PropertyTreeType::value_type & v, propertyTree.equal_range("Include"))
+  const auto iteratorPair = propertyTree.equal_range("Include");
+
+  if (iteratorPair.first != iteratorPair.second)
   {
-    if (FoundIncludes)
+    if (std::next(iteratorPair.first) != iteratorPair.second)
     {
       throw std::runtime_error("Only 1 listing of Includes is allowed per Blueprint file");
     }
-
+    const PropertyTreeType::value_type & v = *iteratorPair.first;
     auto const pathsStrings = VectorizeValues(v.second);
     // convert vector of strings to list of boost::path-s
-    paths.resize(pathsStrings.size());
-    std::transform(pathsStrings.begin(), pathsStrings.end(), paths.begin(),
-      [](std::string p) { return PathType(p); });
-    FoundIncludes = true;
+    paths = PathsType(pathsStrings.cbegin(), pathsStrings.cend());
   }
   return paths;
 }

--- a/Modules/Blueprints/src/selxBlueprintImpl.h
+++ b/Modules/Blueprints/src/selxBlueprintImpl.h
@@ -107,7 +107,7 @@ public:
   typedef boost::graph_traits< GraphType >::out_edge_iterator OutputIteratorType;
   typedef std::pair< OutputIteratorType, OutputIteratorType > OutputIteratorPairType;
 
-  BlueprintImpl( LoggerImpl & loggerImpl);
+  explicit BlueprintImpl( LoggerImpl & loggerImpl);
 
 
   bool SetComponent( ComponentNameType, ParameterMapType parameterMap );
@@ -158,10 +158,10 @@ private:
   using PathType = boost::filesystem::path;
   using PathsType = std::list<PathType>;
 
-  PropertyTreeType ReadPropertyTree(const PathType & filename);
+  static PropertyTreeType ReadPropertyTree(const PathType & filename);
 
-  PathsType FindIncludes(const PropertyTreeType &);
-  ParameterValueType VectorizeValues(ComponentOrConnectionTreeType componentOrConnectionTree);
+  static PathsType FindIncludes(const PropertyTreeType &);
+  static ParameterValueType VectorizeValues(ComponentOrConnectionTreeType componentOrConnectionTree);
 
   Blueprint::Pointer FromPropertyTree(const PropertyTreeType &);
   void MergeProperties(const PropertyTreeType &);

--- a/Modules/Blueprints/src/selxBlueprintImpl.h
+++ b/Modules/Blueprints/src/selxBlueprintImpl.h
@@ -153,7 +153,6 @@ public:
 private:
 
   typedef boost::property_tree::ptree         PropertyTreeType;
-  typedef const boost::property_tree::ptree & ComponentOrConnectionTreeType;
 
   using PathType = boost::filesystem::path;
   using PathsType = std::list<PathType>;
@@ -161,7 +160,7 @@ private:
   static PropertyTreeType ReadPropertyTree(const PathType & filename);
 
   static PathsType FindIncludes(const PropertyTreeType &);
-  static ParameterValueType VectorizeValues(ComponentOrConnectionTreeType componentOrConnectionTree);
+  static ParameterValueType VectorizeValues(const PropertyTreeType& componentOrConnectionTree);
 
   Blueprint::Pointer FromPropertyTree(const PropertyTreeType &);
   void MergeProperties(const PropertyTreeType &);


### PR DESCRIPTION
Seven independent commits to BlueprintImpl. Most important commit: 7508a1f00b279c8c575169a70a757cd996227358

Should fix the first bullet of issue #348 "Fix composable blueprints":
>     * SuperElastix cannot find the included path. We should add logic to SuperElastix that resolves the path the included blueprint. The included path should be the path relative to the blueprint that includes it. 