### PR TITLE
Replace stof/stoi/stoull SyNImageRegistration, improve style of its MeetsCriterion

### DIFF
--- a/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
+++ b/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
@@ -268,7 +268,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 		meetsCriteria = true;
 		if (criterionValues.size() == 1)
 		{
-			if (this->m_NumberOfLevelsLastSetBy == "") // check if some other settings set the NumberOfLevels
+			if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
 			{
 				// try catch?
 				this->m_SyNImageRegistrationMethod->SetNumberOfLevels(std::stoi(criterionValues[0]));
@@ -299,7 +299,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 
 		const int impliedNumberOfResolutions = criterionValues.size();
 
-		if (this->m_NumberOfLevelsLastSetBy == "") // check if some other settings set the NumberOfLevels
+		if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
 		{
 			// try catch?
 			this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
@@ -320,7 +320,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 		shrinkFactorsPerLevel.SetSize(impliedNumberOfResolutions);
 
 		unsigned int resolutionIndex = 0;
-		for (auto const & criterionValue : criterionValues) // auto&& preferred?
+		for (auto const & criterionValue : criterionValues)
 		{
 			shrinkFactorsPerLevel[resolutionIndex] = std::stoi(criterionValue);
 			++resolutionIndex;
@@ -334,7 +334,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 
 		const int impliedNumberOfResolutions = criterionValues.size();
 
-		if (this->m_NumberOfLevelsLastSetBy == "") // check if some other settings set the NumberOfLevels
+		if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
 		{
 			// try catch?
 			this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
@@ -356,7 +356,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 		smoothingSigmasPerLevel.SetSize(impliedNumberOfResolutions);
 
 		unsigned int resolutionIndex = 0;
-		for (auto const & criterionValue : criterionValues) // auto&& preferred?
+		for (auto const & criterionValue : criterionValues)
 		{
 			smoothingSigmasPerLevel[resolutionIndex] = std::stoi(criterionValue);
 			++resolutionIndex;

--- a/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
+++ b/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
@@ -90,16 +90,16 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 
 		FixedRescaleImageFilterPointer fixedIntensityRescaler = FixedRescaleImageFilterType::New();
 		fixedIntensityRescaler->SetInput(fixedImage);
-		fixedIntensityRescaler->SetOutputMinimum(std::stof(this->m_RescaleIntensity[0]));
-		fixedIntensityRescaler->SetOutputMaximum(std::stof(this->m_RescaleIntensity[1]));
+		fixedIntensityRescaler->SetOutputMinimum(StringConverter{ this->m_RescaleIntensity[0] });
+		fixedIntensityRescaler->SetOutputMaximum(StringConverter{ this->m_RescaleIntensity[1] });
 		fixedIntensityRescaler->UpdateOutputInformation();
 		fixedImage = fixedIntensityRescaler->GetOutput();
 		fixedImage->Update();
 
 		MovingRescaleImageFilterPointer movingIntensityRescaler = MovingRescaleImageFilterType::New();
 		movingIntensityRescaler->SetInput(movingImage);
-		movingIntensityRescaler->SetOutputMinimum(std::stof(this->m_RescaleIntensity[0]));
-		movingIntensityRescaler->SetOutputMaximum(std::stof(this->m_RescaleIntensity[1]));
+		movingIntensityRescaler->SetOutputMinimum(StringConverter{ this->m_RescaleIntensity[0] });
+		movingIntensityRescaler->SetOutputMaximum(StringConverter{ this->m_RescaleIntensity[1] });
 		movingIntensityRescaler->UpdateOutputInformation();
 		movingImage = movingIntensityRescaler->GetOutput();
 		movingImage->Update();
@@ -273,12 +273,14 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
       if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
       {
         // try catch?
-        this->m_SyNImageRegistrationMethod->SetNumberOfLevels(std::stoi(criterionValues[0]));
+        this->m_SyNImageRegistrationMethod->SetNumberOfLevels(StringConverter{ criterionValues[0] });
         this->m_NumberOfLevelsLastSetBy = criterionKey;
       }
       else
       {
-        if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != std::stoi(criterionValues[0]))
+        if (!StringConverter::IsStringConvertibleToValue(
+          criterionValues[0],
+          this->m_SyNImageRegistrationMethod->GetNumberOfLevels()))
         {
           // TODO log error?
           std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
@@ -320,7 +322,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
     unsigned int resolutionIndex = 0;
     for (auto const & criterionValue : criterionValues)
     {
-      shrinkFactorsPerLevel[resolutionIndex] = std::stoi(criterionValue);
+      shrinkFactorsPerLevel[resolutionIndex] = StringConverter{ criterionValue };
       ++resolutionIndex;
     }
     // try catch?
@@ -354,7 +356,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
     unsigned int resolutionIndex = 0;
     for (auto const & criterionValue : criterionValues)
     {
-      smoothingSigmasPerLevel[resolutionIndex] = std::stoi(criterionValue);
+      smoothingSigmasPerLevel[resolutionIndex] = StringConverter{ criterionValue };
       ++resolutionIndex;
     }
     // try catch?
@@ -364,7 +366,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
     return true;
   }
   else if (criterionKey == "LearningRate") {
-    this->m_SyNImageRegistrationMethod->SetLearningRate(std::stof(criterionValues[0]));
+    this->m_SyNImageRegistrationMethod->SetLearningRate(StringConverter{ criterionValues[0] });
     return true;
   }
   else if (criterionKey == "NumberOfIterations") {
@@ -376,7 +378,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 
     typename SyNImageRegistrationMethodType::NumberOfIterationsArrayType numberOfIterations(criterionValues.size());
     for (int i = 0; i < criterionValues.size(); i++) {
-      numberOfIterations[i] = stoull(criterionValues[i]);
+      numberOfIterations[i] = StringConverter{ criterionValues[i] };
     }
     this->m_SyNImageRegistrationMethod->SetNumberOfIterationsPerLevel(numberOfIterations);
     return true;
@@ -436,7 +438,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
       return false;
     }
     else {
-      this->m_MetricSamplingPercentage = std::stof(criterionValues[0]);
+      this->m_MetricSamplingPercentage = StringConverter{ criterionValues[0] };
       return true;
     }
   }

--- a/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
+++ b/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
@@ -245,24 +245,28 @@ bool
 ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputationValueType >
 ::MeetsCriterion(const ComponentBase::CriterionType & criterion)
 {
-  bool hasUndefinedCriteria(false);
-
   const auto& criterionKey = criterion.first;
   const auto& criterionValues = criterion.second;
 
   // First check if user-provided properties are template properties and if this component was instantiated with those template properties.
-  auto status = CheckTemplateProperties(this->TemplateProperties(), criterion);
-  if (status == CriterionStatus::Satisfied)
+  switch (CheckTemplateProperties(this->TemplateProperties(), criterion))
   {
-    return true;
+    case CriterionStatus::Satisfied:
+    {
+      return true;
+    }
+    case CriterionStatus::Failed:
+    {
+      return false;
+    }
+    case CriterionStatus::Unknown:
+    {
+      // Just continue.
+    }
   }
-  else if (status == CriterionStatus::Failed)
-  {
-    return false;
-  } // else: CriterionStatus::Unknown
 
   // Next else-if blocks check if the name of setting is an existing property for this component, otherwise MeetsCriterion returns CriterionStatus::Failed.
-  else if (criterionKey == "NumberOfLevels") //Does the Components have this setting?
+  if (criterionKey == "NumberOfLevels") //Does the Components have this setting?
   {
     if (criterionValues.size() == 1)
     {

--- a/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
+++ b/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
@@ -248,6 +248,9 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 	bool hasUndefinedCriteria(false);
 	bool meetsCriteria(false);
 
+  const auto& criterionKey = criterion.first;
+  const auto& criterionValues = criterion.second;
+
 	// First check if user-provided properties are template properties and if this component was instantiated with those template properties.
 	auto status = CheckTemplateProperties(this->TemplateProperties(), criterion);
 	if (status == CriterionStatus::Satisfied)
@@ -260,20 +263,20 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 	} // else: CriterionStatus::Unknown
 
 	// Next else-if blocks check if the name of setting is an existing property for this component, otherwise MeetsCriterion returns CriterionStatus::Failed.
-	else if (criterion.first == "NumberOfLevels") //Does the Components have this setting?
+	else if (criterionKey == "NumberOfLevels") //Does the Components have this setting?
 	{
 		meetsCriteria = true;
-		if (criterion.second.size() == 1)
+		if (criterionValues.size() == 1)
 		{
 			if (this->m_NumberOfLevelsLastSetBy == "") // check if some other settings set the NumberOfLevels
 			{
 				// try catch?
-				this->m_SyNImageRegistrationMethod->SetNumberOfLevels(std::stoi(criterion.second[0]));
-				this->m_NumberOfLevelsLastSetBy = criterion.first;
+				this->m_SyNImageRegistrationMethod->SetNumberOfLevels(std::stoi(criterionValues[0]));
+				this->m_NumberOfLevelsLastSetBy = criterionKey;
 			}
 			else
 			{
-				if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != std::stoi(criterion.second[0]))
+				if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != std::stoi(criterionValues[0]))
 				{
 					// TODO log error?
 					std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
@@ -290,17 +293,17 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 			return meetsCriteria;
 		}
 	}
-	else if (criterion.first == "ShrinkFactorsPerLevel") //Supports this?
+	else if (criterionKey == "ShrinkFactorsPerLevel") //Supports this?
 	{
 		meetsCriteria = true;
 
-		const int impliedNumberOfResolutions = criterion.second.size();
+		const int impliedNumberOfResolutions = criterionValues.size();
 
 		if (this->m_NumberOfLevelsLastSetBy == "") // check if some other settings set the NumberOfLevels
 		{
 			// try catch?
 			this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
-			this->m_NumberOfLevelsLastSetBy = criterion.first;
+			this->m_NumberOfLevelsLastSetBy = criterionKey;
 		}
 		else
 		{
@@ -317,7 +320,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 		shrinkFactorsPerLevel.SetSize(impliedNumberOfResolutions);
 
 		unsigned int resolutionIndex = 0;
-		for (auto const & criterionValue : criterion.second) // auto&& preferred?
+		for (auto const & criterionValue : criterionValues) // auto&& preferred?
 		{
 			shrinkFactorsPerLevel[resolutionIndex] = std::stoi(criterionValue);
 			++resolutionIndex;
@@ -325,17 +328,17 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 		// try catch?
 		this->m_SyNImageRegistrationMethod->SetShrinkFactorsPerLevel(shrinkFactorsPerLevel);
 	}
-	else if (criterion.first == "SmoothingSigmasPerLevel") //Supports this?
+	else if (criterionKey == "SmoothingSigmasPerLevel") //Supports this?
 	{
 		meetsCriteria = true;
 
-		const int impliedNumberOfResolutions = criterion.second.size();
+		const int impliedNumberOfResolutions = criterionValues.size();
 
 		if (this->m_NumberOfLevelsLastSetBy == "") // check if some other settings set the NumberOfLevels
 		{
 			// try catch?
 			this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
-			this->m_NumberOfLevelsLastSetBy = criterion.first;
+			this->m_NumberOfLevelsLastSetBy = criterionKey;
 		}
 		else
 		{
@@ -353,7 +356,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 		smoothingSigmasPerLevel.SetSize(impliedNumberOfResolutions);
 
 		unsigned int resolutionIndex = 0;
-		for (auto const & criterionValue : criterion.second) // auto&& preferred?
+		for (auto const & criterionValue : criterionValues) // auto&& preferred?
 		{
 			smoothingSigmasPerLevel[resolutionIndex] = std::stoi(criterionValue);
 			++resolutionIndex;
@@ -362,34 +365,34 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 		// Smooth by specified gaussian sigmas for each level.  These values are specified in
 		// physical units.
 		this->m_SyNImageRegistrationMethod->SetSmoothingSigmasPerLevel(smoothingSigmasPerLevel);
-	} else if( criterion.first == "LearningRate" ) {
+	} else if( criterionKey == "LearningRate" ) {
 		meetsCriteria = true;
-		this->m_SyNImageRegistrationMethod->SetLearningRate(std::stof(criterion.second[0]));
-	} else if( criterion.first == "NumberOfIterations" ) {
+		this->m_SyNImageRegistrationMethod->SetLearningRate(std::stof(criterionValues[0]));
+	} else if( criterionKey == "NumberOfIterations" ) {
 			meetsCriteria = true;
 
       if(this->m_NumberOfLevelsLastSetBy != "" &&
-         this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != criterion.second.size()) {
+         this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != criterionValues.size()) {
          std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
          return false;
       }
 
-      typename SyNImageRegistrationMethodType::NumberOfIterationsArrayType numberOfIterations(criterion.second.size());
-      for(int i = 0; i < criterion.second.size(); i++) {
-        numberOfIterations[i] = stoull(criterion.second[i]);
+      typename SyNImageRegistrationMethodType::NumberOfIterationsArrayType numberOfIterations(criterionValues.size());
+      for(int i = 0; i < criterionValues.size(); i++) {
+        numberOfIterations[i] = stoull(criterionValues[i]);
       }
       this->m_SyNImageRegistrationMethod->SetNumberOfIterationsPerLevel(numberOfIterations);
 	}
-	else if( criterion.first == "EstimateScales" ) //Supports this?
+	else if( criterionKey == "EstimateScales" ) //Supports this?
 	{
-		if( criterion.second.size() != 1 )
+		if( criterionValues.size() != 1 )
 		{
 			meetsCriteria = false;
 		}
 		else
 		{
 			bool criterionValue = false;
-			meetsCriteria = StringConverter::Convert(*criterion.second.begin(), criterionValue);
+			meetsCriteria = StringConverter::Convert(*criterionValues.begin(), criterionValue);
 
 			if(meetsCriteria)
 			{
@@ -397,48 +400,48 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 				optimizer->SetDoEstimateScales(criterionValue);
 			}
 		}
-	} else if( criterion.first == "RescaleIntensity" ) {
-		if( criterion.second.size() != 2 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected two values for RescaleIntensity (min, max), got {0}.", criterion.second.size());
+	} else if( criterionKey == "RescaleIntensity" ) {
+		if( criterionValues.size() != 2 ) {
+			this->m_Logger.Log(LogLevel::ERR, "Expected two values for RescaleIntensity (min, max), got {0}.", criterionValues.size());
 			meetsCriteria = false;
 		}
 		else {
-			this->m_RescaleIntensity = criterion.second;
+			this->m_RescaleIntensity = criterionValues;
 			meetsCriteria = true;
 		}
-	} else if( criterion.first == "InvertIntensity" ) {
-		if( criterion.second.size() != 1 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected one value for InvertIntensity (True or False), got {0}.", criterion.second.size());
+	} else if( criterionKey == "InvertIntensity" ) {
+		if( criterionValues.size() != 1 ) {
+			this->m_Logger.Log(LogLevel::ERR, "Expected one value for InvertIntensity (True or False), got {0}.", criterionValues.size());
 			meetsCriteria = false;
 		} else {
-			meetsCriteria = StringConverter::Convert(criterion.second[0], this->m_InvertIntensity);
+			meetsCriteria = StringConverter::Convert(criterionValues[0], this->m_InvertIntensity);
 
 			if (!meetsCriteria)
 			{
-				this->m_Logger.Log(LogLevel::ERR, "Expected InvertIntensity to be True or False, got {0}.", criterion.second[0]);
+				this->m_Logger.Log(LogLevel::ERR, "Expected InvertIntensity to be True or False, got {0}.", criterionValues[0]);
 			}
 		}
-	} else if( criterion.first == "MetricSamplingPercentage" ) {
-		if( criterion.second.size() != 1 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingPercetage, got {0}.", criterion.second.size());
+	} else if( criterionKey == "MetricSamplingPercentage" ) {
+		if( criterionValues.size() != 1 ) {
+			this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingPercetage, got {0}.", criterionValues.size());
 			meetsCriteria = false;
 		} else {
-			this->m_MetricSamplingPercentage = std::stof(criterion.second[0]);
+			this->m_MetricSamplingPercentage = std::stof(criterionValues[0]);
 			meetsCriteria = true;
 		}
-	} else if( criterion.first == "MetricSamplingStrategy" ) {
-		if( criterion.second.size() != 1 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingStrategy (Regular or Random), got {0}.", criterion.second.size());
+	} else if( criterionKey == "MetricSamplingStrategy" ) {
+		if( criterionValues.size() != 1 ) {
+			this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingStrategy (Regular or Random), got {0}.", criterionValues.size());
 			meetsCriteria = false;
 		} else {
-			if( criterion.second[0] == "Regular" ) {
+			if( criterionValues[0] == "Regular" ) {
 				this->m_SyNImageRegistrationMethod->SetMetricSamplingStrategy(SyNImageRegistrationMethodType::MetricSamplingStrategyType::REGULAR);
 				meetsCriteria = true;
-			} else if( criterion.second[0] == "Random" ) {
+			} else if( criterionValues[0] == "Random" ) {
 				this->m_SyNImageRegistrationMethod->SetMetricSamplingStrategy(SyNImageRegistrationMethodType::MetricSamplingStrategyType::RANDOM);
 				meetsCriteria = true;
 			} else {
-				this->m_Logger.Log(LogLevel::ERR, "Expected MetricSamplingStrategy to be Regular or Random, got {0}.", criterion.second[0]);
+				this->m_Logger.Log(LogLevel::ERR, "Expected MetricSamplingStrategy to be Regular or Random, got {0}.", criterionValues[0]);
 				meetsCriteria = false;
 			}
 		}

--- a/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
+++ b/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
@@ -243,210 +243,221 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 template< int Dimensionality, class TPixel, class InternalComputationValueType >
 bool
 ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputationValueType >
-::MeetsCriterion( const ComponentBase::CriterionType & criterion )
+::MeetsCriterion(const ComponentBase::CriterionType & criterion)
 {
-	bool hasUndefinedCriteria(false);
-	bool meetsCriteria(false);
+  bool hasUndefinedCriteria(false);
+  bool meetsCriteria(false);
 
   const auto& criterionKey = criterion.first;
   const auto& criterionValues = criterion.second;
 
-	// First check if user-provided properties are template properties and if this component was instantiated with those template properties.
-	auto status = CheckTemplateProperties(this->TemplateProperties(), criterion);
-	if (status == CriterionStatus::Satisfied)
-	{
-		return true;
-	}
-	else if (status == CriterionStatus::Failed)
-	{
-		return false;
-	} // else: CriterionStatus::Unknown
+  // First check if user-provided properties are template properties and if this component was instantiated with those template properties.
+  auto status = CheckTemplateProperties(this->TemplateProperties(), criterion);
+  if (status == CriterionStatus::Satisfied)
+  {
+    return true;
+  }
+  else if (status == CriterionStatus::Failed)
+  {
+    return false;
+  } // else: CriterionStatus::Unknown
 
-	// Next else-if blocks check if the name of setting is an existing property for this component, otherwise MeetsCriterion returns CriterionStatus::Failed.
-	else if (criterionKey == "NumberOfLevels") //Does the Components have this setting?
-	{
-		meetsCriteria = true;
-		if (criterionValues.size() == 1)
-		{
-			if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
-			{
-				// try catch?
-				this->m_SyNImageRegistrationMethod->SetNumberOfLevels(std::stoi(criterionValues[0]));
-				this->m_NumberOfLevelsLastSetBy = criterionKey;
-			}
-			else
-			{
-				if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != std::stoi(criterionValues[0]))
-				{
-					// TODO log error?
-					std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
-					meetsCriteria = false;
-					return meetsCriteria;
-				}
-			}
-		}
-		else
-		{
-			// TODO log error?
-			std::cout << "NumberOfLevels accepts one number only" << std::endl;
-			meetsCriteria = false;
-			return meetsCriteria;
-		}
-	}
-	else if (criterionKey == "ShrinkFactorsPerLevel") //Supports this?
-	{
-		meetsCriteria = true;
-
-		const int impliedNumberOfResolutions = criterionValues.size();
-
-		if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
-		{
-			// try catch?
-			this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
-			this->m_NumberOfLevelsLastSetBy = criterionKey;
-		}
-		else
-		{
-			if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != impliedNumberOfResolutions)
-			{
-				// TODO log error?
-				std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
-				meetsCriteria = false;
-				return meetsCriteria;
-			}
-		}
-
-		itk::Array< itk::SizeValueType > shrinkFactorsPerLevel;
-		shrinkFactorsPerLevel.SetSize(impliedNumberOfResolutions);
-
-		unsigned int resolutionIndex = 0;
-		for (auto const & criterionValue : criterionValues)
-		{
-			shrinkFactorsPerLevel[resolutionIndex] = std::stoi(criterionValue);
-			++resolutionIndex;
-		}
-		// try catch?
-		this->m_SyNImageRegistrationMethod->SetShrinkFactorsPerLevel(shrinkFactorsPerLevel);
-	}
-	else if (criterionKey == "SmoothingSigmasPerLevel") //Supports this?
-	{
-		meetsCriteria = true;
-
-		const int impliedNumberOfResolutions = criterionValues.size();
-
-		if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
-		{
-			// try catch?
-			this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
-			this->m_NumberOfLevelsLastSetBy = criterionKey;
-		}
-		else
-		{
-			if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != impliedNumberOfResolutions)
-			{
-				// TODO log error?
-				std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
-				meetsCriteria = false;
-				return meetsCriteria;
-			}
-		}
-
-		itk::Array< InternalComputationValueType > smoothingSigmasPerLevel;
-
-		smoothingSigmasPerLevel.SetSize(impliedNumberOfResolutions);
-
-		unsigned int resolutionIndex = 0;
-		for (auto const & criterionValue : criterionValues)
-		{
-			smoothingSigmasPerLevel[resolutionIndex] = std::stoi(criterionValue);
-			++resolutionIndex;
-		}
-		// try catch?
-		// Smooth by specified gaussian sigmas for each level.  These values are specified in
-		// physical units.
-		this->m_SyNImageRegistrationMethod->SetSmoothingSigmasPerLevel(smoothingSigmasPerLevel);
-	} else if( criterionKey == "LearningRate" ) {
-		meetsCriteria = true;
-		this->m_SyNImageRegistrationMethod->SetLearningRate(std::stof(criterionValues[0]));
-	} else if( criterionKey == "NumberOfIterations" ) {
-			meetsCriteria = true;
-
-      if(this->m_NumberOfLevelsLastSetBy != "" &&
-         this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != criterionValues.size()) {
-         std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
-         return false;
+  // Next else-if blocks check if the name of setting is an existing property for this component, otherwise MeetsCriterion returns CriterionStatus::Failed.
+  else if (criterionKey == "NumberOfLevels") //Does the Components have this setting?
+  {
+    meetsCriteria = true;
+    if (criterionValues.size() == 1)
+    {
+      if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
+      {
+        // try catch?
+        this->m_SyNImageRegistrationMethod->SetNumberOfLevels(std::stoi(criterionValues[0]));
+        this->m_NumberOfLevelsLastSetBy = criterionKey;
       }
-
-      typename SyNImageRegistrationMethodType::NumberOfIterationsArrayType numberOfIterations(criterionValues.size());
-      for(int i = 0; i < criterionValues.size(); i++) {
-        numberOfIterations[i] = stoull(criterionValues[i]);
+      else
+      {
+        if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != std::stoi(criterionValues[0]))
+        {
+          // TODO log error?
+          std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
+          meetsCriteria = false;
+          return meetsCriteria;
+        }
       }
-      this->m_SyNImageRegistrationMethod->SetNumberOfIterationsPerLevel(numberOfIterations);
-	}
-	else if( criterionKey == "EstimateScales" ) //Supports this?
-	{
-		if( criterionValues.size() != 1 )
-		{
-			meetsCriteria = false;
-		}
-		else
-		{
-			bool criterionValue = false;
-			meetsCriteria = StringConverter::Convert(*criterionValues.begin(), criterionValue);
+    }
+    else
+    {
+      // TODO log error?
+      std::cout << "NumberOfLevels accepts one number only" << std::endl;
+      meetsCriteria = false;
+      return meetsCriteria;
+    }
+  }
+  else if (criterionKey == "ShrinkFactorsPerLevel") //Supports this?
+  {
+    meetsCriteria = true;
 
-			if(meetsCriteria)
-			{
-				auto optimizer = this->m_SyNImageRegistrationMethod->GetModifiableOptimizer();
-				optimizer->SetDoEstimateScales(criterionValue);
-			}
-		}
-	} else if( criterionKey == "RescaleIntensity" ) {
-		if( criterionValues.size() != 2 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected two values for RescaleIntensity (min, max), got {0}.", criterionValues.size());
-			meetsCriteria = false;
-		}
-		else {
-			this->m_RescaleIntensity = criterionValues;
-			meetsCriteria = true;
-		}
-	} else if( criterionKey == "InvertIntensity" ) {
-		if( criterionValues.size() != 1 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected one value for InvertIntensity (True or False), got {0}.", criterionValues.size());
-			meetsCriteria = false;
-		} else {
-			meetsCriteria = StringConverter::Convert(criterionValues[0], this->m_InvertIntensity);
+    const int impliedNumberOfResolutions = criterionValues.size();
 
-			if (!meetsCriteria)
-			{
-				this->m_Logger.Log(LogLevel::ERR, "Expected InvertIntensity to be True or False, got {0}.", criterionValues[0]);
-			}
-		}
-	} else if( criterionKey == "MetricSamplingPercentage" ) {
-		if( criterionValues.size() != 1 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingPercetage, got {0}.", criterionValues.size());
-			meetsCriteria = false;
-		} else {
-			this->m_MetricSamplingPercentage = std::stof(criterionValues[0]);
-			meetsCriteria = true;
-		}
-	} else if( criterionKey == "MetricSamplingStrategy" ) {
-		if( criterionValues.size() != 1 ) {
-			this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingStrategy (Regular or Random), got {0}.", criterionValues.size());
-			meetsCriteria = false;
-		} else {
-			if( criterionValues[0] == "Regular" ) {
-				this->m_SyNImageRegistrationMethod->SetMetricSamplingStrategy(SyNImageRegistrationMethodType::MetricSamplingStrategyType::REGULAR);
-				meetsCriteria = true;
-			} else if( criterionValues[0] == "Random" ) {
-				this->m_SyNImageRegistrationMethod->SetMetricSamplingStrategy(SyNImageRegistrationMethodType::MetricSamplingStrategyType::RANDOM);
-				meetsCriteria = true;
-			} else {
-				this->m_Logger.Log(LogLevel::ERR, "Expected MetricSamplingStrategy to be Regular or Random, got {0}.", criterionValues[0]);
-				meetsCriteria = false;
-			}
-		}
-	}
+    if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
+    {
+      // try catch?
+      this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
+      this->m_NumberOfLevelsLastSetBy = criterionKey;
+    }
+    else
+    {
+      if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != impliedNumberOfResolutions)
+      {
+        // TODO log error?
+        std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
+        meetsCriteria = false;
+        return meetsCriteria;
+      }
+    }
 
-	return meetsCriteria;
+    itk::Array< itk::SizeValueType > shrinkFactorsPerLevel;
+    shrinkFactorsPerLevel.SetSize(impliedNumberOfResolutions);
+
+    unsigned int resolutionIndex = 0;
+    for (auto const & criterionValue : criterionValues)
+    {
+      shrinkFactorsPerLevel[resolutionIndex] = std::stoi(criterionValue);
+      ++resolutionIndex;
+    }
+    // try catch?
+    this->m_SyNImageRegistrationMethod->SetShrinkFactorsPerLevel(shrinkFactorsPerLevel);
+  }
+  else if (criterionKey == "SmoothingSigmasPerLevel") //Supports this?
+  {
+    meetsCriteria = true;
+
+    const int impliedNumberOfResolutions = criterionValues.size();
+
+    if (this->m_NumberOfLevelsLastSetBy.empty()) // check if some other settings set the NumberOfLevels
+    {
+      // try catch?
+      this->m_SyNImageRegistrationMethod->SetNumberOfLevels(impliedNumberOfResolutions);
+      this->m_NumberOfLevelsLastSetBy = criterionKey;
+    }
+    else
+    {
+      if (this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != impliedNumberOfResolutions)
+      {
+        // TODO log error?
+        std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
+        meetsCriteria = false;
+        return meetsCriteria;
+      }
+    }
+
+    itk::Array< InternalComputationValueType > smoothingSigmasPerLevel;
+
+    smoothingSigmasPerLevel.SetSize(impliedNumberOfResolutions);
+
+    unsigned int resolutionIndex = 0;
+    for (auto const & criterionValue : criterionValues)
+    {
+      smoothingSigmasPerLevel[resolutionIndex] = std::stoi(criterionValue);
+      ++resolutionIndex;
+    }
+    // try catch?
+    // Smooth by specified gaussian sigmas for each level.  These values are specified in
+    // physical units.
+    this->m_SyNImageRegistrationMethod->SetSmoothingSigmasPerLevel(smoothingSigmasPerLevel);
+  }
+  else if (criterionKey == "LearningRate") {
+    meetsCriteria = true;
+    this->m_SyNImageRegistrationMethod->SetLearningRate(std::stof(criterionValues[0]));
+  }
+  else if (criterionKey == "NumberOfIterations") {
+    meetsCriteria = true;
+
+    if (this->m_NumberOfLevelsLastSetBy != "" &&
+      this->m_SyNImageRegistrationMethod->GetNumberOfLevels() != criterionValues.size()) {
+      std::cout << "A conflicting NumberOfLevels was set by " << this->m_NumberOfLevelsLastSetBy << std::endl;
+      return false;
+    }
+
+    typename SyNImageRegistrationMethodType::NumberOfIterationsArrayType numberOfIterations(criterionValues.size());
+    for (int i = 0; i < criterionValues.size(); i++) {
+      numberOfIterations[i] = stoull(criterionValues[i]);
+    }
+    this->m_SyNImageRegistrationMethod->SetNumberOfIterationsPerLevel(numberOfIterations);
+  }
+  else if (criterionKey == "EstimateScales") //Supports this?
+  {
+    if (criterionValues.size() != 1)
+    {
+      meetsCriteria = false;
+    }
+    else
+    {
+      bool criterionValue = false;
+      meetsCriteria = StringConverter::Convert(*criterionValues.begin(), criterionValue);
+
+      if (meetsCriteria)
+      {
+        auto optimizer = this->m_SyNImageRegistrationMethod->GetModifiableOptimizer();
+        optimizer->SetDoEstimateScales(criterionValue);
+      }
+    }
+  }
+  else if (criterionKey == "RescaleIntensity") {
+    if (criterionValues.size() != 2) {
+      this->m_Logger.Log(LogLevel::ERR, "Expected two values for RescaleIntensity (min, max), got {0}.", criterionValues.size());
+      meetsCriteria = false;
+    }
+    else {
+      this->m_RescaleIntensity = criterionValues;
+      meetsCriteria = true;
+    }
+  }
+  else if (criterionKey == "InvertIntensity") {
+    if (criterionValues.size() != 1) {
+      this->m_Logger.Log(LogLevel::ERR, "Expected one value for InvertIntensity (True or False), got {0}.", criterionValues.size());
+      meetsCriteria = false;
+    }
+    else {
+      meetsCriteria = StringConverter::Convert(criterionValues[0], this->m_InvertIntensity);
+
+      if (!meetsCriteria)
+      {
+        this->m_Logger.Log(LogLevel::ERR, "Expected InvertIntensity to be True or False, got {0}.", criterionValues[0]);
+      }
+    }
+  }
+  else if (criterionKey == "MetricSamplingPercentage") {
+    if (criterionValues.size() != 1) {
+      this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingPercetage, got {0}.", criterionValues.size());
+      meetsCriteria = false;
+    }
+    else {
+      this->m_MetricSamplingPercentage = std::stof(criterionValues[0]);
+      meetsCriteria = true;
+    }
+  }
+  else if (criterionKey == "MetricSamplingStrategy") {
+    if (criterionValues.size() != 1) {
+      this->m_Logger.Log(LogLevel::ERR, "Expected one value for MetricSamplingStrategy (Regular or Random), got {0}.", criterionValues.size());
+      meetsCriteria = false;
+    }
+    else {
+      if (criterionValues[0] == "Regular") {
+        this->m_SyNImageRegistrationMethod->SetMetricSamplingStrategy(SyNImageRegistrationMethodType::MetricSamplingStrategyType::REGULAR);
+        meetsCriteria = true;
+      }
+      else if (criterionValues[0] == "Random") {
+        this->m_SyNImageRegistrationMethod->SetMetricSamplingStrategy(SyNImageRegistrationMethodType::MetricSamplingStrategyType::RANDOM);
+        meetsCriteria = true;
+      }
+      else {
+        this->m_Logger.Log(LogLevel::ERR, "Expected MetricSamplingStrategy to be Regular or Random, got {0}.", criterionValues[0]);
+        meetsCriteria = false;
+      }
+    }
+  }
+
+  return meetsCriteria;
 }
 } //end namespace selx


### PR DESCRIPTION
Replaces stof/stoi/stoull calls `ItkSyNImageRegistrationMethodComponent` by `StringConverter`, fixing issue #360

Does various style improvements to its `MeetsCriterion` member function.