### PR TITLE
ENH: Add GaussianSmooth + Convergence params SyNImageRegistrationMethod

### DIFF
--- a/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Brains.json
+++ b/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Brains.json
@@ -18,7 +18,7 @@
       "LearningRate": "0.25",
       "PixelType": "float",
       "ConvergenceThreshold": "1.0e-6",
-      "ConvergenceWindow": "10",
+      "ConvergenceWindowSize": "10",
       "GaussianSmoothingVarianceForTheUpdateField": "3",
       "GaussianSmoothingVarianceForTheTotalField": "0.5",
       "RescaleIntensity": ["0", "1"]

--- a/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Brains.json
+++ b/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Brains.json
@@ -17,6 +17,10 @@
       "SmoothingSigmasPerLevel": [ "8", "8", "4", "1"],
       "LearningRate": "0.25",
       "PixelType": "float",
+      "ConvergenceThreshold": "1.0e-6",
+      "ConvergenceWindow": "10",
+      "GaussianSmoothingVarianceForTheUpdateField": "3",
+      "GaussianSmoothingVarianceForTheTotalField": "0.5",
       "RescaleIntensity": ["0", "1"]
     },
     {

--- a/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Lungs.json
+++ b/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Lungs.json
@@ -17,7 +17,7 @@
       "LearningRate": "0.25",
       "PixelType": "float",
       "ConvergenceThreshold": "1.0e-6",
-      "ConvergenceWindow": "10",
+      "ConvergenceWindowSize": "10",
       "GaussianSmoothingVarianceForTheUpdateField": "3",
       "GaussianSmoothingVarianceForTheTotalField": "0.5",
       "RescaleIntensity": ["0", "1"],

--- a/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Lungs.json
+++ b/ContinuousRegistration/Submissions/TeamElastix/ITKv4_SyN_CC_Lungs.json
@@ -16,6 +16,10 @@
       "SmoothingSigmasPerLevel": [ "8", "8", "4", "1"],
       "LearningRate": "0.25",
       "PixelType": "float",
+      "ConvergenceThreshold": "1.0e-6",
+      "ConvergenceWindow": "10",
+      "GaussianSmoothingVarianceForTheUpdateField": "3",
+      "GaussianSmoothingVarianceForTheTotalField": "0.5",
       "RescaleIntensity": ["0", "1"],
       "InvertIntensity": ["True"]
     },

--- a/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
+++ b/Modules/Components/itkSyNImageRegistrationMethod/include/selxItkSyNImageRegistrationMethodComponent.hxx
@@ -247,6 +247,7 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
 {
   const auto& criterionKey = criterion.first;
   const auto& criterionValues = criterion.second;
+  const bool hasOneCriterionValue = criterionValues.size() == 1;
 
   // First check if user-provided properties are template properties and if this component was instantiated with those template properties.
   switch (CheckTemplateProperties(this->TemplateProperties(), criterion))
@@ -367,6 +368,26 @@ ItkSyNImageRegistrationMethodComponent< Dimensionality, TPixel, InternalComputat
   }
   else if (criterionKey == "LearningRate") {
     this->m_SyNImageRegistrationMethod->SetLearningRate(StringConverter{ criterionValues[0] });
+    return true;
+  }
+  else if (hasOneCriterionValue && (criterionKey == "ConvergenceThreshold"))
+  {
+    this->m_SyNImageRegistrationMethod->SetConvergenceThreshold(StringConverter{ criterionValues[0] });
+    return true;
+  }
+  else if (hasOneCriterionValue && (criterionKey == "ConvergenceWindowSize"))
+  {
+    this->m_SyNImageRegistrationMethod->SetConvergenceWindowSize(StringConverter{ criterionValues[0] });
+    return true;
+  }
+  else if (hasOneCriterionValue && (criterionKey == "GaussianSmoothingVarianceForTheUpdateField"))
+  {
+    this->m_SyNImageRegistrationMethod->SetGaussianSmoothingVarianceForTheUpdateField(StringConverter{ criterionValues[0] });
+    return true;
+  }
+  else if (hasOneCriterionValue && (criterionKey == "GaussianSmoothingVarianceForTheTotalField"))
+  {
+    this->m_SyNImageRegistrationMethod->SetGaussianSmoothingVarianceForTheTotalField(StringConverter{ criterionValues[0] });
     return true;
   }
   else if (criterionKey == "NumberOfIterations") {


### PR DESCRIPTION
Added four parameters to the SuperElastix wrapper of `itk::SyNImageRegistrationMethod`:

 * ConvergenceThreshold
 * ConvergenceWindowSize
 * GaussianSmoothingVarianceForTheUpdateField
 * GaussianSmoothingVarianceForTheTotalField